### PR TITLE
FT: Enable keep alive sockets for connection pooling

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -60,6 +60,7 @@ class SproxydClient {
             '/proxy/arc/' : opts.path;
         this.chunkSize = 4 * 1024 * 1024; // 4Mb
         this.setCurrentBootstrap(this.bootstrap[0]);
+        this.httpAgent = new http.Agent({ keepAlive: true });
     }
 
     _shiftCurrentBootstrapToEnd() {
@@ -106,6 +107,7 @@ class SproxydClient {
                 'X-Scal-Replica-Policy': 'immutable',
                 'content-type': 'application/x-www-form-urlencoded',
             },
+            agent: this.httpAgent,
         };
     }
 


### PR DESCRIPTION
Enabling keep alive fixes the max connection errors issue while using
the client.
