### PR TITLE
Fix circle.yml so that CI can work around the GCC 4.9 dep issue

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,10 @@ machine:
     - sudo rm /etc/apt/sources.list.d/circle.list  /etc/apt/sources.list.d/cassandra.list /etc/apt/sources.list.d/google.list
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     - sudo apt-get update
+    - sudo apt-get install libcloog-isl4 libisl10  
+    # command below fails 
+    - mkdir deb &&  cd deb && wget http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu/pool/main/g/gcc-4.9/cpp-4.9_4.9.2-0ubuntu1~12.04_amd64.deb &&  wget http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu/pool/main/g/gcc-4.9/g++-4.9_4.9.2-0ubuntu1~12.04_amd64.deb && wget http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu/pool/main/g/gcc-4.9/gcc-4.9-base_4.9.2-0ubuntu1~12.04_amd64.deb && wget http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu/pool/main/g/gcc-4.9/gcc-4.9_4.9.2-0ubuntu1~12.04_amd64.deb && sudo dpkg -i *deb ; exit 0
+    - sudo apt-get -f install 
     - sudo apt-get install gcc-4.9 g++-4.9
     - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 20
     - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 20


### PR DESCRIPTION
Applying the same changes than on
https://github.com/scality/IronMan-S3/commit/3e898638501a46dbc59bcacb3ed9eb2245554ed6
