### PR TITLE
CI: Build for Node.js 4.2 (new LTS version)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,4 +13,4 @@ machine:
     - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 20
     - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 20
   node:
-    version: 4.1
+    version: 4.2


### PR DESCRIPTION
Node.js v4.2.x "Argon" is the new _Long Term Support_ release. It will
be supported for a period of 30 months.
