### PR TITLE
FIX: call callback only once

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -16,7 +16,7 @@ const keygen = require('./keygen');
  */
 function _createRequest(req, log, callback) {
     return http.request(req, function handleResponse(response) {
-        response.on('readable', () => {
+        response.once('readable', () => {
             if (response.statusCode !== 200) {
                 const error = new Error(response.statusCode);
                 error.isExpected = true;


### PR DESCRIPTION
Each time more data was available, the callback was called, creating a
callback vortex.
