### PR TITLE
Change the log level of sproxyd requests

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -146,19 +146,20 @@ class SproxydClient {
         const value = key ? key : '[data]';
         let counter = tries;
 
-        log.debug('failover request', { method, value, args, counter });
+        log.info('request', { method, value, args, counter });
 
         this._handleRequest(method, stream, key, log, (err, ret) => {
             if (err && !err.isExpected) {
                 if (++counter >= this.bootstrap.length) {
-                    log.error(`failover tried ${counter} times, giving up`);
+                    log.errorEnd('failover tried too many times, giving up',
+                                 { retries: counter });
                     return callback(err);
                 }
                 return this._shiftCurrentBootstrapToEnd(log)
                     ._failover(method, stream, key, counter, log, callback,
                                params);
             }
-            log.debug('failover request received response', { err });
+            log.end('request received response', { err });
             return callback(err, ret);
         }, params);
     }


### PR DESCRIPTION
Change the log level of requests and responses to info.
Compute the elapsed time
