### PR TITLE
Sent the X-Scal-Request-Uids header to sproxyd

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -128,13 +128,14 @@ class SproxydClient {
      * This creates a default request for sproxyd, generating
      * a new key on the fly if needed.
      */
-    _createRequestHeader(method, headers, key, params) {
+    _createRequestHeader(method, reqUids, headers, key, params) {
         const currentKey = key ? key : keygen(params);
         const reqHeaders = headers || {};
 
         const currentBootstrap = this.getCurrentBootstrap();
         reqHeaders['X-Scal-Replica-Policy'] = 'immutable';
         reqHeaders['content-type'] = 'application/octet-stream';
+        reqHeaders['X-Scal-Request-Uids'] = reqUids;
         return {
             hostname: currentBootstrap[0],
             port: currentBootstrap[1],
@@ -145,14 +146,14 @@ class SproxydClient {
         };
     }
 
-    _failover(method, stream, key, tries, log, callback, params) {
+    _failover(method, reqUids, stream, key, tries, log, callback, params) {
         const args = params === undefined ? {} : params;
         const value = key ? key : '[data]';
         let counter = tries;
 
         log.info('request', { method, value, args, counter });
 
-        this._handleRequest(method, stream, key, log, (err, ret) => {
+        this._handleRequest(method, reqUids, stream, key, log, (err, ret) => {
             if (err && !err.isExpected) {
                 if (++counter >= this.bootstrap.length) {
                     log.errorEnd('failover tried too many times, giving up',
@@ -160,7 +161,7 @@ class SproxydClient {
                     return callback(err);
                 }
                 return this._shiftCurrentBootstrapToEnd(log)
-                    ._failover(method, stream, key, counter, log, callback,
+                    ._failover(method, reqUids,stream, key, counter, log, callback,
                                params);
             }
             log.end('request received response', { err });
@@ -172,7 +173,7 @@ class SproxydClient {
      * This does a basic routing of the methods, dealing with the request
      * creation and its sending.
      */
-    _handleRequest(method, stream, key, log, callback, params) {
+    _handleRequest(method, reqUids,stream, key, log, callback, params) {
         const headers = {};
         if (stream) {
             const hashAlgo = params.algo ? params.algo : 'MD5';
@@ -181,7 +182,7 @@ class SproxydClient {
             if (stream.headers && stream.headers['content-length'] !== undefined) {
                 headers['content-length'] = stream.headers['content-length'];
             }
-            const req = this._createRequestHeader(method, headers, null,
+            const req = this._createRequestHeader(method, reqUids,headers, null,
                 params);
             const request = _createRequest(req, log, (err) => {
                 if (err) {
@@ -203,7 +204,7 @@ class SproxydClient {
             log.debug('finished sending PUT chunks to sproxyd');
         } else {
             headers['content-length'] = 0;
-            const req = this._createRequestHeader(method, headers, key);
+            const req = this._createRequestHeader(method, reqUids , headers, key);
             const request = _createRequest(req, log, callback);
             request.end();
         }
@@ -225,7 +226,7 @@ class SproxydClient {
     put(stream, params, reqUids, callback) {
         assert(stream.readable, 'stream should be readable');
         const log = this.createLogger(reqUids);
-        this._failover('PUT', stream, null, 0, log, (err, key) => {
+        this._failover('PUT', reqUids, stream, null, 0, log, (err, key) => {
             if (err)
                 return callback(err);
             if (stream.contentHash
@@ -252,7 +253,7 @@ class SproxydClient {
         assert.strictEqual(typeof key, 'string');
         assert.strictEqual(key.length, 40);
         const log = this.createLogger(reqUids);
-        this._failover('GET', null, key, 0, log, callback);
+        this._failover('GET', reqUids, null, key, 0, log, callback);
     }
 
     /**
@@ -266,7 +267,7 @@ class SproxydClient {
         assert.strictEqual(typeof key, 'string');
         assert.strictEqual(key.length, 40);
         const log = this.createLogger(reqUids);
-        this._failover('DELETE', null, key, 0, log, callback);
+        this._failover('DELETE', reqUids, null, key, 0, log, callback);
     }
 }
 


### PR DESCRIPTION
This PR passes the req_id to tengine/nginx so that sproxyd/tengine can log it.

For example, overwriting the hosts object with 

```
 s3cmd -c /root/s3cfg put /etc/hosts s3://bucket 
```

generates within the tengine 

```
{ "time":"2016-05-30T02:23:44+00:00","connection":"15","request":"1","hrtime":"1464575024.797","httpMethod":"PUT","url":"/arc/F711BBACC2E8F6ABC2A8C034BFD0175914804F70","elapsed_ms":11,"httpCode":200,"requestLength":410,"bytesSent":243,"contentLength":"158","sentContentLength":"81","contentType":"application/octet-stream","s3Address":"10.10.2.1","requestUserMd":"-","responseUserMd":"-","ringKeyVersion":"64","ringStatus":"-","s3Port":"52705","sproxydStatus":"200","req_id":"d349d5ded384358e1135","ifMatch":"-","ifNoneMatch":"-","range":"-","contentRange":"-","nginxPID":12693,"sproxydAddress":"127.0.0.1:20001","sproxydResponseTime_s":"0.011" }
{ "time":"2016-05-30T02:23:44+00:00","connection":"17","request":"1","hrtime":"1464575024.830","httpMethod":"DELETE","url":"/arc/CADB05B81A8335BAC2A8C034BFD0175982A55370","elapsed_ms":10,"httpCode":200,"requestLength":274,"bytesSent":244,"contentLength":"0","sentContentLength":"81","contentType":"application/octet-stream","s3Address":"10.10.2.1","requestUserMd":"-","responseUserMd":"-","ringKeyVersion":"128","ringStatus":"-","s3Port":"52711","sproxydStatus":"200","req_id":"d349d5ded384358e1135:c493d779e2124b034b7c","ifMatch":"-","ifNoneMatch":"-","range":"-","contentRange":"-","nginxPID":12693,"sproxydAddress":"127.0.0.1:20002","sproxydResponseTime_s":"0.010" }
```

it matches the S3 logs:

```
[root@storenode01 ~]# grep d349d5ded384358e1135:c493d779e2124b034b7c /scality/ssd2/ironman-logs/ironman-s3-10.10.2.1/logs/server.log 
{"name":"SproxydClient","hostname":"storenode01","pid":45,"level":30,"method":"DELETE","value":"CADB05B81A8335BAC2A8C034BFD0175982A55370","args":{},"counter":0,"time":"2016-05-30T02:23:44.814Z","req_id":"d349d5ded384358e1135:c493d779e2124b034b7c:b5b868d3eea89906a63c","msg":"request","v":0}
{"name":"SproxydClient","hostname":"storenode01","pid":45,"level":30,"err":null,"time":"2016-05-30T02:23:44.831Z","req_id":"d349d5ded384358e1135:c493d779e2124b034b7c:b5b868d3eea89906a63c","elapsed_ms":16.966977,"msg":"request received response","v":0}
[root@storenode01 ~]# 
```

Ist this ok ? Should the req_id at the nginx/tengine level looks like "req_id":"d349d5ded384358e1135:c493d779e2124b034b7c:b5b868d3eea89906a63c:blalbla" ?
