### PR TITLE
cleanup: remove bunyan-logstash dep. and unused config

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -5,7 +5,6 @@ const crypto = require('crypto');
 const http = require('http');
 const PassThrough = require('stream').PassThrough;
 
-const bunyanLogstash = require('bunyan-logstash');
 const Logger = require('werelogs');
 
 const shuffle = require('./shuffle');
@@ -81,16 +80,6 @@ class SproxydClient {
             options = {
                 level: config.logLevel,
                 dump: config.dumpLevel,
-                streams: [
-                    { stream: process.stdout },
-                    {
-                        type: 'raw',
-                        stream: bunyanLogstash.createStream({
-                            host: config.logstash.host,
-                            port: config.logstash.port,
-                        }),
-                    }
-                ],
             };
         }
         this.logging = new Logger('SproxydClient', options);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "url": "http://www.scality.com/"
   },
   "dependencies": {
-    "bunyan-logstash": "^0.3.4",
     "werelogs": "scality/werelogs#rel/1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This commit removes bunyan-logstash dependency and it's config
that is no longer required by Werelogs.
