### PR TITLE
Sent the X-Scal-Request-Uids header to sproxyd

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -135,15 +135,16 @@ class SproxydClient {
      * This creates a default request for sproxyd, generating
      * a new key on the fly if needed.
      */
-    _createRequestHeader(method, headers, key, params) {
+    _createRequestHeader(method, headers, key, params, log) {
         const currentKey = key || keygen(this.cos, params);
         const reqHeaders = headers || {};
 
         const currentBootstrap = this.getCurrentBootstrap();
         reqHeaders['X-Scal-Replica-Policy'] = 'immutable';
         reqHeaders['content-type'] = 'application/octet-stream';
+        reqHeaders['X-Scal-Request-Uids'] = log.getSerializedUids();
         if(params && params.range){
-            headers['Range'] = `bytes=${params.range[0]}-${params.range[1]}`;
+            reqHeaders['Range'] = `bytes=${params.range[0]}-${params.range[1]}`;
         }
         return {
             hostname: currentBootstrap[0],
@@ -191,7 +192,7 @@ class SproxydClient {
                 headers['content-length'] = stream.headers['content-length'];
             }
             const req = this._createRequestHeader(method, headers, null,
-                params);
+                params, log);
             const request = _createRequest(req, log, (err) => {
                 if (err) {
                     log.error('PUT chunk to sproxyd', { msg: err.message });
@@ -212,7 +213,7 @@ class SproxydClient {
             log.debug('finished sending PUT chunks to sproxyd');
         } else {
             headers['content-length'] = 0;
-            const req = this._createRequestHeader(method, headers, key, params);
+            const req = this._createRequestHeader(method, headers, key, params, log);
             const request = _createRequest(req, log, callback);
             request.end();
         }


### PR DESCRIPTION
Follow up to https://github.com/scality/sproxydclient/pull/64  and https://github.com/scality/sproxydclient/pull/66
The PR is now based on rel/1.0.

Different req_ids are generated for different requests.

Examples of tengine logs with this PR

```
{ "time":"2016-06-01T01:01:56+00:00","connection":"1829219","request":"1","hrtime":"1464742916.806","httpMethod":"PUT","url":"/arc/E9D6E0FBD701CE62C2A8C034BFD0175934994370","elapsed_ms":10,"httpCode":200,"requestLength":431,"bytesSent":243,"contentLength":"158","sentContentLength":"81","contentType":"application/octet-stream","s3Address":"10.10.2.1","requestUserMd":"-","responseUserMd":"-","ringKeyVersion":"64","ringStatus":"-","s3Port":"42222","sproxydStatus":"200","req_id":"a2671e29584cc0f4b922:00295d6b66054dd9e54f","ifMatch":"-","ifNoneMatch":"-","range":"-","contentRange":"-","nginxPID":12695,"sproxydAddress":"127.0.0.1:20008","sproxydResponseTime_s":"0.010" }
{ "time":"2016-06-01T01:01:56+00:00","connection":"1829220","request":"1","hrtime":"1464742916.835","httpMethod":"DELETE","url":"/arc/107DB4F1563999CAC2A8C034BFD0175966A49770","elapsed_ms":6,"httpCode":200,"requestLength":295,"bytesSent":244,"contentLength":"0","sentContentLength":"81","contentType":"application/octet-stream","s3Address":"10.10.2.1","requestUserMd":"-","responseUserMd":"-","ringKeyVersion":"128","ringStatus":"-","s3Port":"42231","sproxydStatus":"200","req_id":"a2671e29584cc0f4b922:375c309e271f56b2f73f:6ff1049074ac2b29e1b7","ifMatch":"-","ifNoneMatch":"-","range":"-","contentRange":"-","nginxPID":12694,"sproxydAddress":"127.0.0.1:20002","sproxydResponseTime_s":"0.006" }
{ "time":"2016-06-01T01:03:21+00:00","connection":"1829221","request":"1","hrtime":"1464743001.458","httpMethod":"GET","url":"/arc/E9D6E0FBD701CE62C2A8C034BFD0175934994370","elapsed_ms":14,"httpCode":200,"requestLength":271,"bytesSent":541,"contentLength":"0","sentContentLength":"158","contentType":"application/octet-stream","s3Address":"10.10.2.1","requestUserMd":"-","responseUserMd":"-","ringKeyVersion":"64","ringStatus":"-","s3Port":"42393","sproxydStatus":"200","req_id":"806201fe7276734024fd:00fd9c5297818a6fff60","ifMatch":"-","ifNoneMatch":"-","range":"-","contentRange":"-","nginxPID":12696,"sproxydAddress":"127.0.0.1:20003","sproxydResponseTime_s":"0.014" }
```

And the S3 server logs

```
{"name":"S3","hostname":"storenode01","pid":30,"level":30,"clientIP":"::ffff:127.0.0.1","url":"/bucket/hosts","httpMethod":"PUT","bucketName":"bucket","objectKey":"hosts","method":"routePUT","time":"2016-06-01T01:01:56.738Z","req_id":"a2671e29584cc0f4b922","msg":"received request","v":0}
{"name":"S3","hostname":"storenode01","pid":30,"level":30,"clientIP":"::ffff:127.0.0.1","url":"/bucket/hosts","httpMethod":"PUT","bucketName":"bucket","objectKey":"hosts","accessKey":"E29IGGCPXR92I3R0QXU9","clientIp":"::ffff:127.0.0.1","clientPort":52246,"httpURL":"/bucket/hosts","httpCode":200,"time":"2016-06-01T01:01:56.828Z","req_id":"a2671e29584cc0f4b922","elapsed_ms":94.550794,"msg":"responded to request","v":0}
{"name":"S3","hostname":"storenode01","pid":45,"level":30,"clientIP":"::ffff:127.0.0.1","url":"/bucket/hosts","httpMethod":"GET","bucketName":"bucket","objectKey":"hosts","method":"routerGET","time":"2016-06-01T01:03:21.398Z","req_id":"806201fe7276734024fd","msg":"received request","v":0}
{"name":"S3","hostname":"storenode01","pid":45,"level":30,"clientIP":"::ffff:127.0.0.1","url":"/bucket/hosts","httpMethod":"GET","bucketName":"bucket","objectKey":"hosts","accessKey":"E29IGGCPXR92I3R0QXU9","clientIp":"::ffff:127.0.0.1","clientPort":52423,"httpURL":"/bucket/hosts","httpCode":200,"time":"2016-06-01T01:03:21.470Z","req_id":"806201fe7276734024fd","elapsed_ms":76.012208,"msg":"responded with streamed content","v":0}
```
