### PR TITLE
TYPO: use field error instead of err

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -162,7 +162,7 @@ class SproxydClient {
                     ._failover(method, stream, size, key, counter, log, callback,
                                params);
             }
-            log.end('request received response', { err });
+            log.end('request received response', { error: err });
             return callback(err, ret);
         }, args);
     }
@@ -179,7 +179,7 @@ class SproxydClient {
             headers['content-length'] = size;
             const request = _createRequest(req, log, (err) => {
                 if (err) {
-                    log.error('PUT chunk to sproxyd', { msg: err.message });
+                    log.error('PUT chunk to sproxyd', { error: err });
                     return callback(err);
                 }
                 // We return the key


### PR DESCRIPTION
FIX #79