### PR TITLE
Remove the readable assertion

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -210,7 +210,6 @@ class SproxydClient {
      * @returns {undefined}
      */
     put(stream, size, params, reqUids, callback, keyScheme) {
-        assert(stream.readable, 'stream should be readable');
         const log = this.createLogger(reqUids);
         this._failover('PUT', stream, size, keyScheme, 0, log, (err, key) => {
             if (err)


### PR DESCRIPTION
Fix #81

Special crypto streams like Decipheriv don't contain readable property.