### PR TITLE
FT: Fix crypto encoding

### DIFF
--- a/lib/keygen.js
+++ b/lib/keygen.js
@@ -6,7 +6,8 @@ const crypto = require('crypto');
 const sid = Buffer.from([ 0x59 ]);
 
 function createMd5(str, len) {
-    return crypto.createHash('md5').update(str).digest().slice(0, len);
+    return crypto.createHash('md5')
+        .update(str, 'binary').digest().slice(0, len);
 }
 
 module.exports = function createKey(cos, params) {


### PR DESCRIPTION
in Node v4, default crypto encoding is binary, this
PR specify this encoding to avoid any change in the future
(node v6 in mind)