### PR TITLE
Fix url for healthcheck http request

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -309,7 +309,7 @@ class SproxydClient {
             hostname: currentBootstrap[0],
             port: currentBootstrap[1],
             method: 'GET',
-            path: '/.conf',
+            path: `${this.path}.conf`,
             headers: {
                 'X-Scal-Request-Uids': logger.getSerializedUids(),
             },

--- a/tests/unit/sproxyd.js
+++ b/tests/unit/sproxyd.js
@@ -46,7 +46,7 @@ function makeResponse(res, code, message, data, md) {
 
 function handler(req, res) {
     const key = req.url.slice(-40);
-    if (req.url === '/.conf' && req.method === 'GET') {
+    if (req.url === '/proxy/arc/.conf' && req.method === 'GET') {
         makeResponse(res, 200, 'OK');
     } else if (!req.url.startsWith('/proxy/arc')) {
         makeResponse(res, 404, 'NoSuchPath');


### PR DESCRIPTION
Fixes the healthcheck http request url to append '.conf' to 'proxy/arc/' and updates the test.