### PR TITLE
FIX: More comprehensive message

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -151,14 +151,19 @@ class SproxydClient {
         let counter = tries;
         log.info('request', { method, value, args, counter });
 
-        let getResponse = false;
+        let receivedResponse = false;
         this._handleRequest(method, stream, size, key, log, (err, ret) => {
             if (err && !err.isExpected) {
-                if (getResponse === true) {
-                    const error = new Error('trying to put data after sproxyd' +
-                        ' send back a response, size of the object is may ' +
-                        `be wrong, expected size: ${size}`);
-                    throw error;
+                if (receivedResponse === true) {
+                    log.fatal('multiple responses from sproxyd, trying to ' +
+                    'write more data to the stream after sproxyd sent a ' +
+                    'response, size of the object could be incorrect', {
+                        error: err,
+                        method: '_failover',
+                        size,
+                        objectKey: key,
+                    });
+                    return undefined;
                 }
                 if (++counter >= this.bootstrap.length) {
                     log.errorEnd('failover tried too many times, giving up',
@@ -169,7 +174,7 @@ class SproxydClient {
                     ._failover(method, stream, size, key, counter, log,
                                callback, params);
             }
-            getResponse = true;
+            receivedResponse = true;
             log.end('request received response', { error: err });
             return callback(err, ret);
         }, args);

--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -151,8 +151,15 @@ class SproxydClient {
         let counter = tries;
         log.info('request', { method, value, args, counter });
 
+        let getResponse = false;
         this._handleRequest(method, stream, size, key, log, (err, ret) => {
             if (err && !err.isExpected) {
+                if (getResponse === true) {
+                    const error = new Error('trying to put data after sproxyd' +
+                        ' send back a response, size of the object is may ' +
+                        `be wrong, expected size: ${size}`);
+                    throw error;
+                }
                 if (++counter >= this.bootstrap.length) {
                     log.errorEnd('failover tried too many times, giving up',
                                  { retries: counter });
@@ -162,6 +169,7 @@ class SproxydClient {
                     ._failover(method, stream, size, key, counter, log,
                                callback, params);
             }
+            getResponse = true;
             log.end('request received response', { error: err });
             return callback(err, ret);
         }, args);


### PR DESCRIPTION
More comprehensive message when trying to put more data than
expected to sproxyd, and avoiding a crash of the worker

See https://github.com/scality/sproxydclient/issues/109