### PR TITLE
fix: change log levels and params

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -168,7 +168,7 @@ class SproxydClient {
     _failover(method, stream, size, key, tries, log, callback, params) {
         const args = params === undefined ? {} : params;
         let counter = tries;
-        log.info('sending request to sproxyd', { method, key, args, counter });
+        log.debug('sending request to sproxyd', { method, key, args, counter });
 
         let receivedResponse = false;
         this._handleRequest(method, stream, size, key, log, (err, ret) => {
@@ -194,7 +194,7 @@ class SproxydClient {
                                callback, params);
             }
             receivedResponse = true;
-            log.end('request received response', { error: err });
+            log.end().debug('request received response');
             return callback(err, ret);
         }, args);
     }


### PR DESCRIPTION
This commit makes sure sproxydclient only writes logs at debug level for a normal requests. Also removes error property at debug level, which was writing log property as error: null.