### PR TITLE
BF/S3C-1026 TCP memory leak

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -13,20 +13,18 @@ const keygen = require('./keygen');
  */
 function _createRequest(req, log, callback) {
     const request = http.request(req, response => {
-        response.once('readable', () => {
-            // Get range returns a 206
-            // Concurrent deletes on sproxyd/immutable keys returns 423
-            if (response.statusCode !== 200 && response.statusCode !== 206 &&
-                !(response.statusCode === 423 && req.method === 'DELETE')) {
-                const error = new Error();
-                error.code = response.statusCode;
-                error.isExpected = true;
-                log.debug('got expected response code:',
-                          { statusCode: response.statusCode });
-                return callback(error);
-            }
-            return callback(null, response);
-        });
+        // Get range returns a 206
+        // Concurrent deletes on sproxyd/immutable keys returns 423
+        if (response.statusCode !== 200 && response.statusCode !== 206 &&
+            !(response.statusCode === 423 && req.method === 'DELETE')) {
+            const error = new Error();
+            error.code = response.statusCode;
+            error.isExpected = true;
+            log.debug('got expected response code:',
+                      { statusCode: response.statusCode });
+            return callback(error);
+        }
+        return callback(null, response);
     }).on('error', callback);
 
     // disable nagle algorithm

--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -228,6 +228,13 @@ class SproxydClient {
                 log.debug('success sending sproxyd request', { host,
                     statusCode: response.statusCode, key: newKey,
                     method: '_handleRequest' });
+                response.once('close', () => {
+                    log.debug('aborting sproxyd request', {
+                        method: 'SproxydClient._handleRequest',
+                    });
+                    // empties the stream and destroys the socket
+                    request.abort();
+                });
                 return callback(null, response);
             });
             request.end();


### PR DESCRIPTION
- **bf: remove unused readable listener**
Removed readable listener as the stream gets generated and ignored.


- **bf: abort sproxyd stream on client close event**
This fixes the issue where sockets are put in CLOSE_WAIT state resulting in
a tcp memory leak. When the client disconnects a close event is emitted.
The listener actively closes the socket and empties the internal buffers
held by the streams.
