### PR TITLE
S3C-1026: tcp leak

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -228,13 +228,6 @@ class SproxydClient {
                 log.debug('success sending sproxyd request', { host,
                     statusCode: response.statusCode, key: newKey,
                     method: '_handleRequest' });
-                response.once('close', () => {
-                    log.debug('aborting sproxyd request', {
-                        method: 'SproxydClient._handleRequest',
-                    });
-                    // empties the stream and destroys the socket
-                    request.abort();
-                });
                 return callback(null, response);
             });
             request.end();


### PR DESCRIPTION
Remove listener on response: this is irrelevant since the request is already
finished when we reach this handler.