### PR TITLE
bugfix: S3C-2197 propagate trace-id to sproxyd

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -127,9 +127,11 @@ class SproxydClient {
         const reqHeaders = headers || {};
 
         const currentBootstrap = this.getCurrentBootstrap();
+        const reqUids = log.getSerializedUids();
         reqHeaders['X-Scal-Replica-Policy'] = 'immutable';
         reqHeaders['content-type'] = 'application/octet-stream';
-        reqHeaders['X-Scal-Request-Uids'] = log.getSerializedUids();
+        reqHeaders['X-Scal-Request-Uids'] = reqUids;
+        reqHeaders['X-Scal-Trace-Ids'] = reqUids;
         if (params && params.range) {
             /* eslint-disable dot-notation */
             reqHeaders['Range'] = `bytes=${params.range[0]}-${params.range[1]}`;


### PR DESCRIPTION
This allows a request to be traced from S3 stack to biziod