### PR TITLE
bugfix: S3C-2369 limit batch delete items

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -1,5 +1,5 @@
 'use strict'; // eslint-disable-line strict
-
+const async = require('async');
 const assert = require('assert');
 const http = require('http');
 const werelogs = require('werelogs');
@@ -370,10 +370,17 @@ class SproxydClient {
     batchDelete(list, reqUids, callback) {
         assert.strictEqual(typeof list, 'object');
         assert(list.keys.every(k => k.length === 40));
-        const log = this.createLogger(reqUids);
-        const payload = Buffer.from(JSON.stringify(list));
-        this._failover('POST', null, payload.length, '.batch_delete', 0, log,
-            callback, {}, payload);
+        // split the list into batches of 1000 each
+        const batches = [];
+        while (list.keys.length > 0) {
+            batches.push({ keys: list.keys.splice(0, 1000) });
+        }
+        async.eachLimit(batches, 5, (b, done) => {
+            const log = this.createLogger(reqUids);
+            const payload = Buffer.from(JSON.stringify(b));
+            this._failover('POST', null, payload.length, '.batch_delete', 0,
+                log, done, {}, payload);
+        }, callback);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "author": "Giorgio Regni",
   "dependencies": {
+    "async": "^3.1.0",
     "werelogs": "scality/werelogs#4e0d97c"
   },
   "devDependencies": {

--- a/tests/unit/sproxyd.js
+++ b/tests/unit/sproxyd.js
@@ -247,7 +247,7 @@ describe('Sproxyd client', () => {
             });
 
             it('should return success for batch delete', done => {
-                const list = _batchDelKeys(5);
+                const list = _batchDelKeys(2000);
                 client.batchDelete(list, reqUid, err => {
                     assert.strictEqual(err, null);
                     done();

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,6 +59,11 @@ argparse@^1.0.7, argparse@~1.0.2:
   dependencies:
     sprintf-js "~1.0.2"
 
+async@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.1.0.tgz#42b3b12ae1b74927b5217d8c0016baaf62463772"
+  integrity sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ==
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"


### PR DESCRIPTION
Sproxyd batch delete allows upto 1000 keys in a request. This commit
splits the keys into batches of upto 1000, sent 5 requests at a time
to avoid overwhelming sproxyd.

(cherry picked from commit 0e17e27b35971aab4bc9a6ce40f7eab2f054314e)