### PR TITLE
Bugfix: S3C-2407 Last request id is sent to sproxyd.

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -135,6 +135,25 @@ class SproxydClient {
         return indexes;
     }
 
+    /**
+     * This returns the last id from the array of request ids.
+     * Sproxyd does not accept ':' in the request ids,
+     * so the last id from the array of request ids is passed.
+     *
+     * @param {Object} log - The log from s3
+     *
+     * @returns {String} - The last request id
+     */
+    _getLastReqUid(log) {
+        let reqUids = [];
+
+        if (log) {
+            reqUids = log.getUids();
+        }
+
+        return reqUids.pop();
+    }
+
     /*
      * This creates a default request for sproxyd, generating
      * a new key on the fly if needed.
@@ -143,7 +162,7 @@ class SproxydClient {
         const reqHeaders = headers || {};
 
         const currentBootstrap = this.getCurrentBootstrap();
-        const reqUids = log.getSerializedUids();
+        const reqUids = this._getLastReqUid(log);
         if (this.immutable) {
             reqHeaders['X-Scal-Replica-Policy'] = 'immutable';
         }
@@ -398,7 +417,7 @@ class SproxydClient {
             method: 'GET',
             path: `${this.path}.conf`,
             headers: {
-                'X-Scal-Request-Uids': logger.getSerializedUids(),
+                'X-Scal-Request-Uids': this._getLastReqUid(logger),
             },
             agent: this.httpAgent,
         };

--- a/tests/unit/sproxyd.js
+++ b/tests/unit/sproxyd.js
@@ -37,9 +37,9 @@ function generateMD() {
 
 function generateKey() {
     const tmp = crypto.createHash('md5').update(crypto.randomBytes(1024)
-            .toString()).digest().slice(0, 10);
+        .toString()).digest().slice(0, 10);
     const tmp2 = crypto.createHash('md5').update(crypto.randomBytes(1024)
-            .toString()).digest().slice(0, 10);
+        .toString()).digest().slice(0, 10);
     return Buffer.concat([tmp, tmp2]).toString('hex').toUpperCase();
 }
 
@@ -71,7 +71,7 @@ function handler(req, res) {
     if (expectedRequestHeaders) {
         Object.keys(expectedRequestHeaders).forEach(header => {
             assert.strictEqual(req.headers[header],
-                               expectedRequestHeaders[header]);
+                expectedRequestHeaders[header]);
         });
     }
     if (notExpectedRequestHeaders) {
@@ -94,7 +94,7 @@ function handler(req, res) {
             req.on('data', data => {
                 server[key] = Buffer.concat([server[key], data]);
             })
-            .on('end', () => makeResponse(res, 200, 'OK'));
+                .on('end', () => makeResponse(res, 200, 'OK'));
         }
     } else if (req.method === 'GET') {
         if (!server[key]) {
@@ -179,10 +179,10 @@ describe('Sproxyd client', () => {
                 upStream.push(upload);
                 upStream.push(null);
                 client.put(upStream, upload.length, parameters, reqUid,
-                           (err, key) => {
-                               savedKey = key;
-                               done(err);
-                           });
+                    (err, key) => {
+                        savedKey = key;
+                        done(err);
+                    });
             });
 
             it('should get some data via sproxyd', done => {
@@ -212,7 +212,7 @@ describe('Sproxyd client', () => {
                     error.isExpected = true;
                     error.code = 404;
                     assert.deepStrictEqual(err, error,
-                                           'Doesn\'t fail properly');
+                        'Doesn\'t fail properly');
                     done();
                 });
             });
@@ -263,6 +263,18 @@ describe('Sproxyd client', () => {
                 assert.strictEqual(response.statusCode, 200);
                 done();
             });
+        });
+    });
+
+    describe('Get last request uid', () => {
+        it('should return a request id without colon', () => {
+            const uids = 'id1:id2:id3';
+            const log = clientNonImmutable.createLogger(uids);
+            const lastRequestUid = clientNonImmutable._getLastReqUid(log);
+            const ids = log.getUids();
+            assert.notStrictEqual(lastRequestUid, undefined);
+            assert.strictEqual(lastRequestUid.indexOf(':'), -1);
+            assert.strictEqual(ids.pop(), lastRequestUid);
         });
     });
 });


### PR DESCRIPTION
S3 sends a req_id with ":" inside, and sproxyd rejects such a request ID. To fix this, the last request id from the logger is passed on to sproxyd.