### PR TITLE
Bugfix: S3C-2040 Use correct request id

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -136,13 +136,24 @@ class SproxydClient {
     }
 
     /**
-     * This returns the last id from the array of request ids.
-     * Sproxyd does not accept ':' in the request ids,
-     * so the last id from the array of request ids is passed.
-     *
-     * @param {Object} log - The log from s3
-     *
-     * @returns {String} - The last request id
+     * Returns the first id from the array of request ids.
+     * @param {Object} log - log from s3
+     * @returns {String} - first request id
+     */
+    _getFirstReqUid(log) {
+        let reqUids = [];
+
+        if (log) {
+            reqUids = log.getUids();
+        }
+
+        return reqUids[0];
+    }
+
+    /**
+     * Returns the last id from the array of request ids.
+     * @param {Object} log - log from s3
+     * @returns {String} - last request id
      */
     _getLastReqUid(log) {
         let reqUids = [];
@@ -162,7 +173,7 @@ class SproxydClient {
         const reqHeaders = headers || {};
 
         const currentBootstrap = this.getCurrentBootstrap();
-        const reqUids = this._getLastReqUid(log);
+        const reqUids = this._getFirstReqUid(log);
         if (this.immutable) {
             reqHeaders['X-Scal-Replica-Policy'] = 'immutable';
         }
@@ -417,7 +428,7 @@ class SproxydClient {
             method: 'GET',
             path: `${this.path}.conf`,
             headers: {
-                'X-Scal-Request-Uids': this._getLastReqUid(logger),
+                'X-Scal-Request-Uids': this._getFirstReqUid(logger),
             },
             agent: this.httpAgent,
         };

--- a/tests/unit/sproxyd.js
+++ b/tests/unit/sproxyd.js
@@ -266,12 +266,20 @@ describe('Sproxyd client', () => {
         });
     });
 
-    describe('Get last request uid', () => {
-        it('should return a request id without colon', () => {
-            const uids = 'id1:id2:id3';
-            const log = clientNonImmutable.createLogger(uids);
+    describe('Get request uid', () => {
+        const uids = 'id1:id2:id3';
+        const log = clientNonImmutable.createLogger(uids);
+        const ids = log.getUids();
+
+        it('should return first request id without colon', () => {
+            const firstRequestUid = clientNonImmutable._getFirstReqUid(log);
+            assert.notStrictEqual(firstRequestUid, undefined);
+            assert.strictEqual(firstRequestUid.indexOf(':'), -1);
+            assert.strictEqual(ids[0], firstRequestUid);
+        });
+
+        it('should return last request id without colon', () => {
             const lastRequestUid = clientNonImmutable._getLastReqUid(log);
-            const ids = log.getUids();
             assert.notStrictEqual(lastRequestUid, undefined);
             assert.strictEqual(lastRequestUid.indexOf(':'), -1);
             assert.strictEqual(ids.pop(), lastRequestUid);


### PR DESCRIPTION
Correct request id is passed from cloud server to sproxyd. 