### PR TITLE
INTEGRATION [PR#192 > development/8.0] bugfix: S3C-2504 abort sproxyd request on input stream close

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -244,10 +244,13 @@ class SproxydClient {
                                               log);
         if (stream) {
             headers['content-length'] = size;
+            let voluntaryAbort = false;
             const request = _createRequest(req, log, (err, response) => {
                 if (err) {
-                    log.error('putting chunk to sproxyd', { host, key: newKey,
-                        error: err });
+                    if (!voluntaryAbort) {
+                        log.error('putting chunk to sproxyd', {
+                            host, key: newKey, error: err });
+                    }
                     return callback(err);
                 }
                 // We return the key
@@ -264,11 +267,18 @@ class SproxydClient {
             stream.pipe(request);
             stream.on('error', err => {
                 log.error('error from readable stream', {
-                    error: err,
+                    error: err.message,
                     method: '_handleRequest',
                     component: 'sproxydclient',
                 });
-                request.end();
+            });
+            stream.on('close', () => {
+                log.trace('readable stream closed', {
+                    method: '_handleRequest',
+                    component: 'sproxydclient',
+                });
+                request.abort();
+                voluntaryAbort = true;
             });
         } else {
             headers['content-length'] = isBatchDelete ? size : 0;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=10"
   },
-  "version": "7.4.1",
+  "version": "7.4.6",
   "description": "sproxyd client",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/sproxyd.js
+++ b/tests/unit/sproxyd.js
@@ -175,7 +175,7 @@ describe('Sproxyd client', () => {
                 notExpectedRequestHeaders = undefined;
             });
             it('should put some data via sproxyd', done => {
-                const upStream = new stream.Readable;
+                const upStream = new stream.PassThrough;
                 upStream.push(upload);
                 upStream.push(null);
                 client.put(upStream, upload.length, parameters, reqUid,
@@ -252,6 +252,19 @@ describe('Sproxyd client', () => {
                     assert.strictEqual(err, null);
                     done();
                 });
+            });
+
+            it('should abort an unfinished request', done => {
+                const upStream = new stream.PassThrough;
+                upStream.push(upload.slice(0, upload.length - 10));
+                setTimeout(() => upStream.destroy(), 500);
+                client.put(upStream, upload.length, parameters, reqUid,
+                    err => {
+                        if (err) {
+                            done();
+                        }
+                        assert.fail('expected an immediate error from sproxyd');
+                    });
             });
         });
     });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #192.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.0/bugfix/S3C-2504-abortSproxydRequestOnStreamError`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.0/bugfix/S3C-2504-abortSproxydRequestOnStreamError
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.0/bugfix/S3C-2504-abortSproxydRequestOnStreamError
```

Please always comment pull request #192 instead of this one.