### PR TITLE
bugfix: S3C-2527 effectively reuse sproxyd connections

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -12,6 +12,11 @@ const keygen = require('./keygen');
  */
 function _createRequest(req, log, callback) {
     const request = http.request(req, response => {
+        // Consume the response body first when not relevant for the
+        // request type, i.e. not a GET
+        if (req.method !== 'GET') {
+            response.resume();
+        }
         // Get range returns a 206
         // Concurrent deletes on sproxyd/immutable keys returns 423
         if (response.statusCode !== 200 && response.statusCode !== 206 &&

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=10"
   },
-  "version": "7.4.6",
+  "version": "7.4.7",
   "description": "sproxyd client",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Make sure we consume and drain the response body of PUT, POST and DELETE
requests coming from sproxyd, in order to be able to reuse the same
connection for new requests.

Inspired by the HDController fix in
https://github.com/scality/hdclient/pull/32/commits/e3e643025bad0955a4d76cf9123f1aa0b6bacbeb.