### PR TITLE
INTEGRATION [PR#195 > development/7.6] bugfix: S3C-2527 effectively reuse sproxyd connections

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -12,6 +12,11 @@ const keygen = require('./keygen');
  */
 function _createRequest(req, log, callback) {
     const request = http.request(req, response => {
+        // Consume the response body first when not relevant for the
+        // request type, i.e. not a GET
+        if (req.method !== 'GET') {
+            response.resume();
+        }
         // Get range returns a 206
         // Concurrent deletes on sproxyd/immutable keys returns 423
         if (response.statusCode !== 200 && response.statusCode !== 206 &&

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=10"
   },
-  "version": "7.4.6",
+  "version": "7.4.7",
   "description": "sproxyd client",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #195.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.6/bugfix/S3C-2527-effectivelyReuseSproxydConnections`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.6/bugfix/S3C-2527-effectivelyReuseSproxydConnections
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.6/bugfix/S3C-2527-effectivelyReuseSproxydConnections
```

Please always comment pull request #195 instead of this one.