### PR TITLE
INTEGRATION [PR#239 > development/8.0] build(deps): [security] bump lodash from 4.17.15 to 4.17.21

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -618,9 +618,9 @@ linkify-it@~1.2.0:
     uc.micro "^1.0.1"
 
 lodash@^4.0.0, lodash@^4.3.0:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lru-cache@2:
   version "2.7.3"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #239.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.0/dependabot/npm_and_yarn/lodash-4.17.21`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.0/dependabot/npm_and_yarn/lodash-4.17.21
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.0/dependabot/npm_and_yarn/lodash-4.17.21
```

Please always comment pull request #239 instead of this one.