### PR TITLE
bugfix: SPRXCLT-5 do not abort PUT requests

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -3,6 +3,7 @@
 const async = require('async');
 const assert = require('assert');
 const http = require('http');
+const { finished } = require('stream');
 const werelogs = require('werelogs');
 
 const shuffle = require('./shuffle');
@@ -282,13 +283,20 @@ class SproxydClient {
                     component: 'sproxydclient',
                 });
             });
-            stream.on('close', () => {
-                log.trace('readable stream closed', {
-                    method: '_handleRequest',
-                    component: 'sproxydclient',
-                });
-                request.abort();
-                voluntaryAbort = true;
+            finished(stream, err => {
+                if (err) {
+                    log.trace('readable stream aborted', {
+                        method: '_handleRequest',
+                        component: 'sproxydclient',
+                    });
+                    request.abort();
+                    voluntaryAbort = true;
+                } else {
+                    log.trace('readable stream finished normally', {
+                        method: '_handleRequest',
+                        component: 'sproxydclient',
+                    });
+                }
             });
         } else {
             headers['content-length'] = isBatchDelete ? size : 0;

--- a/tests/unit/sproxyd.js
+++ b/tests/unit/sproxyd.js
@@ -176,8 +176,8 @@ describe('Sproxyd client', () => {
             });
             it('should put some data via sproxyd', done => {
                 const upStream = new stream.PassThrough();
-                upStream.push(upload);
-                upStream.push(null);
+                upStream.write(upload);
+                upStream.end();
                 client.put(upStream, upload.length, parameters, reqUid,
                     (err, key) => {
                         savedKey = key;
@@ -256,7 +256,7 @@ describe('Sproxyd client', () => {
 
             it('should abort an unfinished request', done => {
                 const upStream = new stream.PassThrough();
-                upStream.push(upload.slice(0, upload.length - 10));
+                upStream.write(upload.slice(0, upload.length - 10));
                 setTimeout(() => upStream.destroy(), 500);
                 client.put(upStream, upload.length, parameters, reqUid,
                     err => {


### PR DESCRIPTION
Fix behavior with node 16 by not relying on the emission of the 'close' event of the source stream to decide that the request to sproxyd should be aborted. Instead, use the "stream.finished" helper function that is designed to handle this case.

It is believed that the regression comes from a change in the default value of "autoDestroy" on streams to "true" in node 14.x, leading to streams being destroyed automatically after completion.
