### PR TITLE
INTEGRATION [PR#290 > development/7.10] bugfix: SPRXCLT-5 do not abort PUT requests

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -3,6 +3,7 @@
 const async = require('async');
 const assert = require('assert');
 const http = require('http');
+const { finished } = require('stream');
 const werelogs = require('werelogs');
 
 const shuffle = require('./shuffle');
@@ -282,13 +283,20 @@ class SproxydClient {
                     component: 'sproxydclient',
                 });
             });
-            stream.on('close', () => {
-                log.trace('readable stream closed', {
-                    method: '_handleRequest',
-                    component: 'sproxydclient',
-                });
-                request.abort();
-                voluntaryAbort = true;
+            finished(stream, err => {
+                if (err) {
+                    log.trace('readable stream aborted', {
+                        method: '_handleRequest',
+                        component: 'sproxydclient',
+                    });
+                    request.abort();
+                    voluntaryAbort = true;
+                } else {
+                    log.trace('readable stream finished normally', {
+                        method: '_handleRequest',
+                        component: 'sproxydclient',
+                    });
+                }
             });
         } else {
             headers['content-length'] = isBatchDelete ? size : 0;

--- a/tests/unit/sproxyd.js
+++ b/tests/unit/sproxyd.js
@@ -176,8 +176,8 @@ describe('Sproxyd client', () => {
             });
             it('should put some data via sproxyd', done => {
                 const upStream = new stream.PassThrough();
-                upStream.push(upload);
-                upStream.push(null);
+                upStream.write(upload);
+                upStream.end();
                 client.put(upStream, upload.length, parameters, reqUid,
                     (err, key) => {
                         savedKey = key;
@@ -256,7 +256,7 @@ describe('Sproxyd client', () => {
 
             it('should abort an unfinished request', done => {
                 const upStream = new stream.PassThrough();
-                upStream.push(upload.slice(0, upload.length - 10));
+                upStream.write(upload.slice(0, upload.length - 10));
                 setTimeout(() => upStream.destroy(), 500);
                 client.put(upStream, upload.length, parameters, reqUid,
                     err => {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #290.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/bugfix/SPRXCLT-5-fixAbortHandlingWithNode16`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/bugfix/SPRXCLT-5-fixAbortHandlingWithNode16
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/bugfix/SPRXCLT-5-fixAbortHandlingWithNode16
```

Please always comment pull request #290 instead of this one.