### PR TITLE
INTEGRATION [PR#291 > development/7.10] bugfix: SPRXCLT-5 do not abort PUT requests

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -3,6 +3,7 @@
 const async = require('async');
 const assert = require('assert');
 const http = require('http');
+const { finished } = require('stream');
 const werelogs = require('werelogs');
 
 const shuffle = require('./shuffle');
@@ -282,15 +283,21 @@ class SproxydClient {
                     component: 'sproxydclient',
                 });
             });
-            // SPRXCLT-5 Handle the TCP memory leak during chunked uploads
-            // stream.on('close', () => {
-            //     log.trace('readable stream closed', {
-            //         method: '_handleRequest',
-            //         component: 'sproxydclient',
-            //     });
-            //     request.abort();
-            //     voluntaryAbort = true;
-            // });
+            finished(stream, err => {
+                if (err) {
+                    log.trace('readable stream aborted', {
+                        method: '_handleRequest',
+                        component: 'sproxydclient',
+                    });
+                    request.abort();
+                    voluntaryAbort = true;
+                } else {
+                    log.trace('readable stream finished normally', {
+                        method: '_handleRequest',
+                        component: 'sproxydclient',
+                    });
+                }
+            });
         } else {
             headers['content-length'] = isBatchDelete ? size : 0;
             const contentType = headers['content-type'];

--- a/tests/unit/sproxyd.js
+++ b/tests/unit/sproxyd.js
@@ -176,8 +176,8 @@ describe('Sproxyd client', () => {
             });
             it('should put some data via sproxyd', done => {
                 const upStream = new stream.PassThrough();
-                upStream.push(upload);
-                upStream.push(null);
+                upStream.write(upload);
+                upStream.end();
                 client.put(upStream, upload.length, parameters, reqUid,
                     (err, key) => {
                         savedKey = key;
@@ -254,20 +254,19 @@ describe('Sproxyd client', () => {
                 });
             });
 
-            // SPRXCLT-5 Handle the TCP memory leak during chunked uploads
-            // it('should abort an unfinished request', done => {
-            //     const upStream = new stream.PassThrough();
-            //     upStream.push(upload.slice(0, upload.length - 10));
-            //     setTimeout(() => upStream.destroy(), 500);
-            //     client.put(upStream, upload.length, parameters, reqUid,
-            //         err => {
-            //             if (err) {
-            //                 done();
-            //             } else {
-            //                 assert.fail('expected an immediate error from sproxyd');
-            //             }
-            //         });
-            // });
+            it('should abort an unfinished request', done => {
+                const upStream = new stream.PassThrough();
+                upStream.write(upload.slice(0, upload.length - 10));
+                setTimeout(() => upStream.destroy(), 500);
+                client.put(upStream, upload.length, parameters, reqUid,
+                    err => {
+                        if (err) {
+                            done();
+                        } else {
+                            assert.fail('expected an immediate error from sproxyd');
+                        }
+                    });
+            });
         });
     });
 


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #291.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/bugfix/SPRXCLT-5-fixAbortHandlingWithNode16-stab-7.10.3`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/bugfix/SPRXCLT-5-fixAbortHandlingWithNode16-stab-7.10.3
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/bugfix/SPRXCLT-5-fixAbortHandlingWithNode16-stab-7.10.3
```

Please always comment pull request #291 instead of this one.