### PR TITLE
bf: SPRXCLT-20 handle 404 error appropriately

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -378,15 +378,19 @@ class SproxydClient {
                 : contentType;
             const request = _createRequest(req, log, (err, response) => {
                 if (err) {
+                    if (err.code === 404) {
+                        log.debug('sproxyd responded with error 404 not found');
+                        return callback(err);
+                    }
                     const errorProcessed = err;
                     // non-streaming are always retryable;
                     errorProcessed.retryable = true;
-                    log.error('error sending sproxyd request', {
+                    log.error('error during sproxyd request', {
                         error: errorProcessed,
                     });
                     return callback(errorProcessed);
                 }
-                log.debug('success sending sproxyd request', {
+                log.debug('success of sproxyd request', {
                     statusCode: response.statusCode,
                 });
                 return callback(null, response);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "sproxyd client",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/sproxyd.js
+++ b/tests/unit/sproxyd.js
@@ -259,7 +259,6 @@ const clientImmutableWithFailover = new Sproxy({
                 const error = new Error();
                 error.isExpected = true;
                 error.code = 404;
-                error.retryable = true;
                 assert.deepStrictEqual(err, error,
                     'Doesn\'t fail properly');
                 done();


### PR DESCRIPTION
- turn error log into a debug log

- remove flag 'retryable' from the returned error object, as 404 is inherently not retryable

Also main request/response log messages are now more generic as they should be.
