### PR TITLE
SPRXCLT-21: Add head() method to return full HTTP headers

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -319,7 +319,7 @@ class SproxydClient {
                 });
                 return callback(null, newKey);
             });
-    
+
             const startPayloadStreaming = () => {
                 // Once we start piping the stream, it starts being consumed and
                 // we can't replay it (in the current implementation)
@@ -463,13 +463,14 @@ class SproxydClient {
     }
 
     /**
-     * This sends a HEAD request to sproxyd.
+     * This sends a HEAD request to sproxyd and returns only the x-scal-usermd header.
      * @param {String} key - The key to get from datastore
      * @param {String} reqUids - The serialized request id
-     * @param {SproxydClient~getCallback} callback - callback
+     * @param {SproxydClient~getCallback} callback - callback(err, usermd)
+     *   where usermd is the x-scal-usermd header value (base64 string)
      * @returns {undefined}
      */
-    getHEAD(key, reqUids, callback) {
+    getUserMetadata(key, reqUids, callback) {
         assert.strictEqual(typeof key, 'string');
         assert.strictEqual(key.length, 40);
         const log = this.createLogger(reqUids);
@@ -481,6 +482,34 @@ class SproxydClient {
                 return callback(null, res.headers['x-scal-usermd']);
             }
             return callback();
+        });
+    }
+
+    /**
+     * This sends a HEAD request to sproxyd and returns all HTTP headers.
+     * @param {String} key - The key to get from datastore
+     * @param {String} reqUids - The serialized request id
+     * @param {SproxydClient~headCallback} callback - callback(err, headers)
+     *   where headers is an object containing all HTTP response headers:
+     *   {
+     *     'content-length': '6715',
+     *     'x-scal-usermd': 'c29tZW1ldGFkYXRhCg==',
+     *     'x-scal-size': '6715',
+     *     'content-type': 'application/octet-stream',
+     *     ... etc
+     *   }
+     * @returns {undefined}
+     */
+    head(key, reqUids, callback) {
+        assert.strictEqual(typeof key, 'string');
+        assert.strictEqual(key.length, 40);
+        const log = this.createLogger(reqUids);
+        this._failover('HEAD', null, 0, key, 0, log, (err, res) => {
+            if (err) {
+                return callback(err);
+            }
+            // Return full headers object so caller can access content-length, etc.
+            return callback(null, res.headers);
         });
     }
 
@@ -557,6 +586,12 @@ class SproxydClient {
  * @callback SproxydClient~getCallback
  * @param {Error} - The encountered error
  * @param {stream.Readable} stream - The stream of values fetched
+ */
+
+/**
+ * @callback SproxydClient~headCallback
+ * @param {Error} - The encountered error
+ * @param {Object} headers - HTTP response headers object
  */
 
 /**

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.1.1",
+  "version": "8.2.0",
   "description": "sproxyd client",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/sproxyd.js
+++ b/tests/unit/sproxyd.js
@@ -278,7 +278,7 @@ const clientImmutableWithFailover = new Sproxy({
         });
 
         it('Should get the md of the object', done => {
-            client.getHEAD(savedKey, reqUid, (err, data) => {
+            client.getUserMetadata(savedKey, reqUid, (err, data) => {
                 assert.strictEqual(err, null);
                 assert.strictEqual(data, mdHex);
                 done();
@@ -286,7 +286,7 @@ const clientImmutableWithFailover = new Sproxy({
         });
 
         it('Get HEAD should return an error', done => {
-            client.getHEAD(generateKey(), reqUid, err => {
+            client.getUserMetadata(generateKey(), reqUid, err => {
                 assert.notStrictEqual(err, null);
                 assert.notStrictEqual(err, undefined);
                 assert.strictEqual(err.code, 404);


### PR DESCRIPTION
- Add new head() method that returns complete headers object
- Keeps existing getHEAD() for backward compatibility (returns only x-scal-usermd)