### PR TITLE
SPRXCLT-23: support query params and conditional PUT/DELETE in putEmptyObject

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -211,11 +211,13 @@ class SproxydClient {
         if (params && params.range) {
             reqHeaders['Range'] = `bytes=${params.range[0]}-${params.range[1]}`;
         }
+        const query = params && params.query
+            ? `?${new URLSearchParams(params.query).toString()}` : '';
         return {
             hostname: currentBootstrap[0],
             port: currentBootstrap[1],
             method,
-            path: `${this.path}${key}`,
+            path: `${this.path}${key}${query}`,
             headers: reqHeaders,
             agent: this.httpAgent,
         };
@@ -378,8 +380,10 @@ class SproxydClient {
                 : contentType;
             const request = _createRequest(req, log, (err, response) => {
                 if (err) {
-                    if (err.code === 404) {
-                        log.debug('sproxyd responded with error 404 not found');
+                    if (err.isExpected) {
+                        log.debug('sproxyd responded with expected error', {
+                            statusCode: err.code,
+                        });
                         return callback(err);
                     }
                     const errorProcessed = err;
@@ -425,23 +429,30 @@ class SproxydClient {
     }
 
     /**
-     * This sends a PUT request to sproxyd without data.
-     * @param {String} keyScheme - sproxyd key for put the metadata
-     * @param {String}  metadata - metadata to put in the object
+     * This sends an empty-body PUT request to sproxyd.
+     * @param {String} keyScheme - sproxyd key
+     * @param {String} metadata - metadata to set in x-scal-usermd header
+     * @param {Object} params - optional parameters
+     * @param {Object} [params.headers] - additional request headers (e.g. If-None-Match)
+     * @param {Object} [params.query] - query parameters as key-value pairs (e.g. { version: 64 })
      * @param {String} reqUids - The serialized request id
      * @param {SproxydClient~putCallback} callback - callback
      * @returns {undefined}
      */
-    putEmptyObject(keyScheme, metadata, reqUids, callback) {
+    putEmptyObject(keyScheme, metadata, params, reqUids, callback) {
         const log = this.createLogger(reqUids);
-        const params = { headers: {} };
-        params.headers['x-scal-usermd'] = metadata;
-        this._failover('PUT', null, 0, keyScheme, 0, log, (err, key) => {
+        const reqParams = Object.assign({}, params, {
+            headers: Object.assign({}, params && params.headers),
+        });
+        reqParams.headers['x-scal-usermd'] = metadata;
+        this._failover('PUT', null, 0, keyScheme, 0, log, (err, response) => {
             if (err) {
                 return callback(err);
             }
-            return callback(null, key);
-        }, params);
+            const version = response && response.headers
+                ? response.headers['x-scal-version'] : undefined;
+            return callback(null, version);
+        }, reqParams);
     }
 
     /**
@@ -526,6 +537,27 @@ class SproxydClient {
         assert.strictEqual(key.length, 40);
         const log = this.createLogger(reqUids);
         this._failover('DELETE', null, 0, key, 0, log, callback);
+    }
+
+    /**
+     * This sends a DELETE request to sproxyd with optional query parameters.
+     * @param {String} key - The key associated to the values
+     * @param {Object} params - optional parameters
+     * @param {Object} [params.query] - query parameters as key-value pairs (e.g. { version: 64 })
+     * @param {String} reqUids - The serialized request id
+     * @param {SproxydClient~deleteCallback} callback - callback
+     * @returns {undefined}
+     */
+    deleteWithParams(key, params, reqUids, callback) {
+        assert.strictEqual(typeof key, 'string');
+        assert.strictEqual(key.length, 40);
+        const log = this.createLogger(reqUids);
+        this._failover('DELETE', null, 0, key, 0, log, err => {
+            if (err) {
+                return callback(err);
+            }
+            return callback(null);
+        }, params);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.2.0",
+  "version": "9.0.0",
   "description": "sproxyd client",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/sproxyd.js
+++ b/tests/unit/sproxyd.js
@@ -16,6 +16,7 @@ const upload = cryptoLib.randomBytes(9000);
 let savedKey;
 let server;
 const md = {};
+const versions = {};
 let mdHex;
 let expectedRequestHeaders;
 let notExpectedRequestHeaders;
@@ -70,7 +71,7 @@ function checkKeyContent(client, key, body, reqUid, callback) {
     });
 }
 
-function makeResponse(res, code, message, data, md) {
+function makeResponse(res, code, message, data, md, version) {
     /* eslint-disable no-param-reassign */
     res.statusCode = code;
     res.statusMessage = message;
@@ -81,6 +82,9 @@ function makeResponse(res, code, message, data, md) {
     if (md) {
         res.setHeader('x-scal-usermd', md);
     }
+    if (version !== undefined) {
+        res.setHeader('x-scal-version', version.toString());
+    }
     res.end();
 }
 
@@ -89,7 +93,9 @@ function consumeAndMakeResponse(req, res, code, message, data, md) {
 }
 
 function handler(req, res) {
-    const key = req.url.slice(-40);
+    const [urlPath, queryString] = req.url.split('?');
+    const key = urlPath.slice(-40);
+    const query = new URLSearchParams(queryString || '');
     if (expectedRequestHeaders) {
         Object.keys(expectedRequestHeaders).forEach(header => {
             assert.strictEqual(req.headers[header],
@@ -103,21 +109,38 @@ function handler(req, res) {
     }
     if (req.url === '/proxy/arc/.conf' && req.method === 'GET') {
         consumeAndMakeResponse(req, res, 200, 'OK');
-    } else if (!req.url.startsWith('/proxy/arc')) {
+    } else if (!urlPath.startsWith('/proxy/arc')) {
         consumeAndMakeResponse(req, res, 404, 'NoSuchPath');
     } else if (req.method === 'PUT') {
-        if (server[key]) {
-            consumeAndMakeResponse(req, res, 404, 'AlreadyExists');
-        } else {
-            server[key] = Buffer.alloc(0);
-            if (req.headers['x-scal-usermd']) {
-                md[key] = req.headers['x-scal-usermd'];
+        const versionParam = query.get('version');
+        if (versionParam !== null) {
+            // conditional PUT: 422 if key absent, 412 if version mismatch
+            if (server[key] === undefined) {
+                consumeAndMakeResponse(req, res, 422, 'UnprocessableEntity');
+                return;
             }
-            req.on('data', data => {
-                server[key] = Buffer.concat([server[key], data]);
-            })
-                .on('end', () => makeResponse(res, 200, 'OK'));
+            const expectedVersion = parseInt(versionParam, 10);
+            if (versions[key] !== expectedVersion) {
+                consumeAndMakeResponse(req, res, 412, 'PreconditionFailed');
+                return;
+            }
+        } else if (req.headers['if-none-match'] === '*') {
+            // fresh create: only succeed if key does not exist
+            if (server[key] !== undefined) {
+                consumeAndMakeResponse(req, res, 412, 'PreconditionFailed');
+                return;
+            }
         }
+        server[key] = Buffer.alloc(0);
+        if (req.headers['x-scal-usermd']) {
+            md[key] = req.headers['x-scal-usermd'];
+        }
+        versions[key] = (versions[key] || 0) + 64;
+        req.on('data', data => {
+            server[key] = Buffer.concat([server[key], data]);
+        })
+            .on('end', () => makeResponse(res, 200, 'OK', null, null,
+                versions[key]));
     } else if (req.method === 'GET') {
         if (!server[key]) {
             consumeAndMakeResponse(req, res, 404, 'NoSuchPath');
@@ -127,18 +150,31 @@ function handler(req, res) {
     } else if (req.method === 'DELETE') {
         if (key === lockedObjectKey) {
             consumeAndMakeResponse(req, res, 423, 'Locked');
+            return;
+        }
+        const deleteVersionParam = query.get('version');
+        if (deleteVersionParam !== null) {
+            if (server[key] === undefined) {
+                consumeAndMakeResponse(req, res, 422, 'UnprocessableEntity');
+                return;
+            }
+            const expectedVersion = parseInt(deleteVersionParam, 10);
+            if (versions[key] !== expectedVersion) {
+                consumeAndMakeResponse(req, res, 412, 'PreconditionFailed');
+                return;
+            }
         } else if (!server[key]) {
             consumeAndMakeResponse(req, res, 404, 'NoSuchPath');
-        } else {
-            delete server[key];
-            if (md[key]) {
-                delete md[key];
-            }
-            consumeAndMakeResponse(req, res, 200, 'OK');
+            return;
         }
+        delete server[key];
+        delete md[key];
+        delete versions[key];
+        consumeAndMakeResponse(req, res, 200, 'OK');
     } else if (req.method === 'HEAD') {
         if (server[key]) {
-            consumeAndMakeResponse(req, res, 200, 'OK', null, md[key]);
+            req.resume().on('end', () =>
+                makeResponse(res, 200, 'OK', null, md[key], versions[key]));
         } else {
             consumeAndMakeResponse(req, res, 404, 'NoSuchPath');
         }
@@ -272,8 +308,10 @@ const clientImmutableWithFailover = new Sproxy({
         it('should put an empty object via sproxyd', done => {
             savedKey = generateKey();
             mdHex = generateMD();
-            client.putEmptyObject(savedKey, mdHex, reqUid, err => {
-                done(err);
+            client.putEmptyObject(savedKey, mdHex, {}, reqUid, (err, version) => {
+                assert.strictEqual(err, null);
+                assert(version, 'expected version from putEmptyObject');
+                done();
             });
         });
 
@@ -298,6 +336,106 @@ const clientImmutableWithFailover = new Sproxy({
             const list = _batchDelKeys(2000);
             client.batchDelete(list, reqUid, err => {
                 assert.strictEqual(err, null);
+                done();
+            });
+        });
+
+        it('should put an empty object with If-None-Match on a fresh key', done => {
+            const key = generateKey();
+            const meta = generateMD();
+            client.putEmptyObject(key, meta, {
+                headers: { 'If-None-Match': '*' },
+            }, reqUid, err => {
+                done(err);
+            });
+        });
+
+        it('should fail put with If-None-Match when key already exists', done => {
+            const key = generateKey();
+            const meta = generateMD();
+            async.series([
+                next => client.putEmptyObject(key, meta, {}, reqUid, next),
+                next => client.putEmptyObject(key, meta, {
+                    headers: { 'If-None-Match': '*' },
+                }, reqUid, err => {
+                    assert(err, 'expected error for duplicate key with If-None-Match');
+                    assert.strictEqual(err.code, 412);
+                    next();
+                }),
+            ], done);
+        });
+
+        it('should succeed conditional PUT with matching version', done => {
+            const key = generateKey();
+            const meta = generateMD();
+            const meta2 = generateMD();
+            async.waterfall([
+                next => client.putEmptyObject(key, meta, {}, reqUid, next),
+                (version, next) => {
+                    assert(version, 'expected version from putEmptyObject');
+                    client.putEmptyObject(key, meta2, {
+                        query: { version },
+                    }, reqUid, next);
+                },
+            ], done);
+        });
+
+        it('should fail conditional PUT with wrong version', done => {
+            const key = generateKey();
+            const meta = generateMD();
+            async.series([
+                next => client.putEmptyObject(key, meta, {}, reqUid, next),
+                next => client.putEmptyObject(key, meta, {
+                    query: { version: 0 },
+                }, reqUid, err => {
+                    assert(err, 'expected error for wrong version');
+                    assert.strictEqual(err.code, 412);
+                    next();
+                }),
+            ], done);
+        });
+
+        it('should return 422 for conditional PUT on non-existent key', done => {
+            const key = generateKey();
+            const meta = generateMD();
+            client.putEmptyObject(key, meta, {
+                query: { version: 64 },
+            }, reqUid, err => {
+                assert(err, 'expected error for version on missing key');
+                assert.strictEqual(err.code, 422);
+                done();
+            });
+        });
+
+        it('should delete an object conditionally via deleteWithParams', done => {
+            const key = generateKey();
+            const meta = generateMD();
+            async.waterfall([
+                next => client.putEmptyObject(key, meta, {}, reqUid, next),
+                (version, next) => client.deleteWithParams(key,
+                    { query: { version } }, reqUid, next),
+            ], done);
+        });
+
+        it('should fail deleteWithParams with wrong version', done => {
+            const key = generateKey();
+            const meta = generateMD();
+            async.series([
+                next => client.putEmptyObject(key, meta, {}, reqUid, next),
+                next => client.deleteWithParams(key,
+                    { query: { version: 0 } }, reqUid, err => {
+                        assert(err, 'expected error for wrong version');
+                        assert.strictEqual(err.code, 412);
+                        next();
+                    }),
+            ], done);
+        });
+
+        it('should return 422 for deleteWithParams on non-existent key', done => {
+            const key = generateKey();
+            client.deleteWithParams(key, { query: { version: 64 } }, reqUid, err => {
+                assert(err, 'expected error for version on missing key');
+                assert.strictEqual(err.code, 422);
                 done();
             });
         });


### PR DESCRIPTION
## Summary

- `_createRequestHeader`: append query string from `params.query` to the request path
- `putEmptyObject`: accept `params` object (`params.headers`, `params.query`); return `x-scal-version` from PUT response as second callback argument (not the key)
- `putEmptyObject`: fix non-streaming error handling to propagate expected errors (`err.isExpected`) rather than always wrapping in `InternalError`
- `deleteWithParams`: new method — version-conditional DELETE via `params.query.version`; avoids changing the existing `delete()` signature for backward compatibility

## Tests

- Test server: support conditional PUT/DELETE (version param, `If-None-Match: *`), track per-key versions, return `x-scal-version` in PUT/HEAD responses
- Update existing `putEmptyObject` and conditional-PUT tests for new signatures
- Add three `deleteWithParams` tests (matching version, wrong version, absent key)

## Motivation

Required by MD-1241 (`lib/ring/Lease.js` in the metadata service), which uses these capabilities to implement a distributed lease backed by a RING object with atomic acquire, steal, renew, and release.

## Test plan

- [ ] `yarn test` passes (existing + new unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)