### PR TITLE
SPRXCLT-27: accept any 2xx as a successful sproxyd response

### DIFF
--- a/lib/sproxyd.js
+++ b/lib/sproxyd.js
@@ -20,10 +20,14 @@ function _createRequest(req, log, callback) {
         if (req.method !== 'GET') {
             response.resume();
         }
-        // Get range returns a 206
+        // Any 2xx is a success: a range GET returns 206, and sproxyd returns
+        // 204 on DELETE and on POST .batch_delete
+        const isSuccess = response.statusCode >= 200
+            && response.statusCode < 300;
         // Concurrent deletes on sproxyd/immutable keys returns 423
-        if (response.statusCode !== 200 && response.statusCode !== 206
-            && !(response.statusCode === 423 && req.method === 'DELETE')) {
+        const isExpectedDeleteConflict =
+            response.statusCode === 423 && req.method === 'DELETE';
+        if (!isSuccess && !isExpectedDeleteConflict) {
             const error = new Error();
             error.code = response.statusCode;
             error.isExpected = true;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "sproxyd client",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/sproxyd.js
+++ b/tests/unit/sproxyd.js
@@ -127,14 +127,14 @@ function handler(req, res) {
     } else if (req.method === 'DELETE') {
         if (key === lockedObjectKey) {
             consumeAndMakeResponse(req, res, 423, 'Locked');
-        } else if (!server[key]) {
-            consumeAndMakeResponse(req, res, 404, 'NoSuchPath');
         } else {
+            // sproxyd deletes are idempotent: they answer 204 whether or not
+            // the key was there
             delete server[key];
             if (md[key]) {
                 delete md[key];
             }
-            consumeAndMakeResponse(req, res, 200, 'OK');
+            consumeAndMakeResponse(req, res, 204, 'No Content');
         }
     } else if (req.method === 'HEAD') {
         if (server[key]) {
@@ -143,7 +143,8 @@ function handler(req, res) {
             consumeAndMakeResponse(req, res, 404, 'NoSuchPath');
         }
     } else if (req.method === 'POST') {
-        consumeAndMakeResponse(req, res, 200, 'OK');
+        // sproxyd answers 204 on POST .batch_delete
+        consumeAndMakeResponse(req, res, 204, 'No Content');
     } else {
         throw new Error(`unexpected HTTP method: ${req.method}`);
     }


### PR DESCRIPTION
Recent sproxyd builds answer `204 No Content` on batch delete and on delete, but this client only ever treated `200` and `206` as success, so both of those responses surfaced to callers as errors. Deleting an already-absent key is routine for cloudserver, which made the failures frequent rather than exotic.

The client now accepts any 2xx, keeping the existing tolerance for the conflict status returned by concurrent deletes on immutable keys. Accepting the whole range rather than adding 204 to a list means a future success code needs no further client change. Both the old and the new codes are accepted, since deployments will be running a mix of sproxyd builds while the new ones roll out.